### PR TITLE
Modernized GHAs

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -13,39 +13,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish-operator:${{ steps.get_version.outputs.VERSION }}
           file: ./Dockerfile
           build-args: |
             VERSION=${{ steps.get_version.outputs.VERSION }}
-          push: ${{ github.event_name == 'release' && github.event.action == 'created' }} #push only on release
+          push: ${{ github.event_name == 'release' && github.event.action == 'created' }}
   varnishd:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish:${{ steps.get_version.outputs.VERSION }}
@@ -55,17 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish-controller:${{ steps.get_version.outputs.VERSION }}
@@ -77,17 +77,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish-metrics-exporter:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -18,12 +18,12 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish-operator:${{ steps.get_version.outputs.VERSION }}
@@ -40,12 +40,12 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish:${{ steps.get_version.outputs.VERSION }}
@@ -60,12 +60,12 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish-controller:${{ steps.get_version.outputs.VERSION }}
@@ -82,12 +82,12 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_PASSWORD}}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_REPO }}/varnish-metrics-exporter:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,11 +22,11 @@ jobs:
           fi
           echo "DOCKERHUB_REPO=$repo" >> $GITHUB_ENV
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get dependencies
         run: go mod download
       - name: build images
@@ -36,13 +36,17 @@ jobs:
           docker build --platform linux/amd64 -f Dockerfile.controller -t ${{ env.DOCKERHUB_REPO }}/varnish-controller:local .
           docker build --platform linux/amd64 -f Dockerfile.exporter -t ${{ env.DOCKERHUB_REPO }}/varnish-metrics-exporter:local .
       - name: Create k8s Kind Cluster ${{ matrix.kubernetes-version }}
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
         with:
           version: v0.29.0
           cluster_name: e2e-tests
           node_image: kindest/node:v${{ matrix.kubernetes-version }}
           kubectl_version: v${{ matrix.kubernetes-version }}
           wait: 120s
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v4.2.0
       - name: create namespace
         run: kubectl create namespace varnish-operator
       - name: load images
@@ -65,14 +69,14 @@ jobs:
           tar -cvf kind-e2e-logs-${{ matrix.kubernetes-version }}.tar ./kind-logs
       - name: upload kind logs artifact
         if: ${{ always() && (steps.e2e.outcome == 'failure' || steps.helm.outcome == 'failure') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: kind-e2e-logs-${{ matrix.kubernetes-version }}.tar
           path: kind-e2e-logs-${{ matrix.kubernetes-version }}.tar
           retention-days: 7
       - name: upload e2e test logs artifact
         if: ${{ always() && steps.e2e.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: debug-logs-${{ matrix.kubernetes-version }}.tar
           path: /tmp/debug-logs/

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -4,48 +4,54 @@ on:
   release:
     types:
       - created
-  push: {}
+  push:
+    branches-ignore:
+      - gh-pages
+
+permissions:
+  contents: write
 
 jobs:
   helm-chart:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
-      - name: Get Helm
-        run: |
-          curl -Lo ./helm.tar.gz https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz
-          mkdir -p bin
-          tar -zxvf ./helm.tar.gz && mv linux-amd64/helm bin/
-          rm helm.tar.gz
-          rm -rf linux-amd64
+        uses: actions/checkout@v4
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
       - name: Helm lint
         run: helm lint varnish-operator
       - name: Ensure helm-releases folder exists
         run: mkdir -p helm-releases
       - name: Get version
-        id: get_version
         run: |
-          if [ ${{ github.event_name }} == 'release' ]; then
-            echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
           else
-            echo "VERSION=v0.0.0-${GITHUB_REF##*/}" >> $GITHUB_ENV
+            echo "VERSION=v0.0.0-${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
           fi
       - name: Change versions
         run: |
-          curl -Lo ./bin/yq https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64
-          chmod +x ./bin/yq
-          ./bin/yq w -i varnish-operator/Chart.yaml 'appVersion' $VERSION
-          ./bin/yq w -i varnish-operator/Chart.yaml 'version' $VERSION
-          ./bin/yq w -i varnish-operator/values.yaml 'container.tag' $VERSION
+          curl -fsSL -o ./yq https://github.com/mikefarah/yq/releases/download/v3.4.3/yq_linux_amd64
+          chmod +x ./yq
+          ./yq w -i varnish-operator/Chart.yaml appVersion "$VERSION"
+          ./yq w -i varnish-operator/Chart.yaml version "$VERSION"
+          ./yq w -i varnish-operator/values.yaml container.tag "$VERSION"
       - name: Package chart
         run: |
-          git config --global user.email ""
-          git config --global user.name "Github Actions CI"
-          ./bin/helm package varnish-operator --app-version $VERSION --version $VERSION --destination helm-releases
-          helm repo index helm-releases --url https://raw.githubusercontent.com/IBM/varnish-operator/main/helm-releases
-          git add helm-releases/*
-          git commit -a -m "Release $VERSION"
+          git config user.email "actions@github.com"
+          git config user.name "github-actions[bot]"
+          helm package varnish-operator \
+            --app-version "$VERSION" \
+            --version "$VERSION" \
+            --destination helm-releases
+          helm repo index helm-releases \
+            --url "https://raw.githubusercontent.com/${{ github.repository }}/main/helm-releases"
+          git add helm-releases/
+          git commit -m "Release $VERSION"
       - name: Push chart
-        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-        run: git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:main
+        if: github.event_name == 'release' && github.event.action == 'created'
+        run: |
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:main

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -34,7 +34,7 @@ jobs:
           fi
       - name: Change versions
         run: |
-          curl -fsSL -o ./yq https://github.com/mikefarah/yq/releases/download/v3.4.3/yq_linux_amd64
+          curl -fsSL -o ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
           chmod +x ./yq
           ./yq w -i varnish-operator/Chart.yaml appVersion "$VERSION"
           ./yq w -i varnish-operator/Chart.yaml version "$VERSION"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.16.4
+          version: v4.2.0
       - name: Helm lint
         run: helm lint varnish-operator
       - name: Ensure helm-releases folder exists

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.4
       - name: Helm lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          cache-dependency-path: go.sum
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -23,18 +24,18 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v5
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: "1.26"
-      id: go
+        cache-dependency-path: go.sum
     - name: Setup envtest binaries
       run: |
         go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
         KUBEBUILDER_ASSETS="$(setup-envtest use 1.36.0 -p path)"
         echo "KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS}" >> $GITHUB_ENV
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v5
     - name: Get dependencies
       run: go mod download
     - name: Unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup-go installation
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           # v1.x binaries are built with Go <1.26 and cannot lint go 1.26 modules
           version: v2.9.0
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: "1.26"
       id: go
@@ -34,7 +34,7 @@ jobs:
         KUBEBUILDER_ASSETS="$(setup-envtest use 1.36.0 -p path)"
         echo "KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS}" >> $GITHUB_ENV
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Get dependencies
       run: go mod download
     - name: Unit tests


### PR DESCRIPTION
## Summary

Modernizes all GitHub Actions workflows to drop deprecated tooling and align with current runner requirements.

- **Helm chart workflow** — Replace manual Helm 3.8.1 install with `azure/setup-helm@v5` and **Helm 4.2.0**; fix yq download URL (`3.4.1`); add `contents: write`, skip `gh-pages` pushes, use `${{ github.repository }}` for repo index URL, and fix git identity for chart commits.
- **Docs workflow** — Remove `node:10.16-jessie` container (GLIBC broke `actions/checkout`); build with **Node 20** + `npm ci` / `npm run build` in `docs/` (HonKit; merged on `main` in #11).
- **Node 24 actions** — Bump `checkout@v5`, `setup-go@v6`, `setup-node@v6`, `upload-artifact@v5`, `golangci-lint-action@v9`, and Docker actions (`setup-buildx@v4`, `login@v3`, `build-push@v6`) to clear Node 20 deprecation warnings.
- **E2E** — Pin **Helm 4.2.0** for `helm install`, bump `kind-action` to v1.14.0.
- **Containers** — Replace deprecated `::set-output` with `$GITHUB_OUTPUT`.

## Notes

- Non-release Helm runs set `VERSION=v0.0.0-<branch>`; Helm 4 may lint-warn on non-SemVer chart versions (packaging still succeeds).
- Helm chart push to `main` still runs only on **release created**.

## Test plan

- [x] Helm Chart workflow — lint + package on push
- [x] Tests / Lint — pass on push
- [x] End-to-end tests — pass on PR
- [ ] Docs — pass on push to `main` (after rebase)
- [x] Containers — build jobs succeed on push (images push only on release)
- [x] Confirm Node 20 deprecation warnings are gone from action logs